### PR TITLE
Move dependency from old javax.servlet-api to new jakarta.servlet-api

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -82,9 +82,9 @@
 
         <!-- Servlet -->
         <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
-            <version>4.0.1</version>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
+            <version>4.0.4</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
detected with:
```
$ mvn -q biz.lermitage.oga:oga-maven-plugin:1.2.1-SNAPSHOT:check 
[ERROR] 'javax.servlet:javax.servlet-api' should be replaced by 'jakarta.servlet:jakarta.servlet-api' (context: Java EE new home is Jakarta EE, see https://wiki.eclipse.org/Jakarta_EE_Maven_Coordinates)
```